### PR TITLE
Adding "isInitialized" Property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,11 +48,13 @@ import draw from "./draw";
 import defaults from "./defaults";
 
 const jalaliDatepicker = {
+    isInitialized: false,
     init(options) {
         this.updateOptions(options);
         addEventListenerOnResize();
         if (this.options.autoHide) addEventListenerOnBody();
         if (this.options.autoShow) addEventListenerOnInputs(this.options.selector);
+        this.isInitialized = true;
     },
     updateOptions(options) {
         this.options = normalizeOptions(options);


### PR DESCRIPTION
Hi Dear Friend,

First, thank you so much for this handy Jalali date picker. I've used it in several projects. For some reason, I needed to have an "isInitialized" property, so I added it to its index.js, and I had to make a little change to the webpack.config.js file (target: ["web", "es5"]) to make a release with Node.js v18. So if you find this useful, please accept the pull request.

Thanks again,
Omid

P.S. I've used this property to prevent calling jalaliDatepicker.startWatch() more than once on the page.

If (!jalaliDatepicker.isInitialized) {
    jalaliDatepicker.startWatch();
}