### PR TITLE
Fix: Add Esc key support to close datepicker and remove focus from input field

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -32,6 +32,7 @@ export const EVENT_CHANGE_YEAR_INPUT_STR = "keyup change";
 export const EVENT_CHANGE_TIME_DROPDOWN_STR = "change";
 export const EVENT_CLICK_STR = "click";
 export const EVENT_FOCUS_STR = "focusin";
+export const EVENT_KEYDOWN_STR = "keydown";
 
 export const MIN_MAX_TODAY_SETTING = "today";
 export const MIN_MAX_ATTR_SETTING = "attr";

--- a/src/index.js
+++ b/src/index.js
@@ -150,12 +150,14 @@ const jalaliDatepicker = {
         }, 300);
         this.setPosition();
         setScrollOnParent(input);
+        document.addEventListener("keydown", handleEscKey);
     },
     hide() {
         this.dpContainer.style.visibility = STYLE_VISIBILITY_HIDDEN;
         this.dpContainer.style.display = STYLE_DISPLAY_HIDDEN;
         this.overlayElm.style.display = STYLE_DISPLAY_HIDDEN;
         this.isShow = false;
+        document.removeEventListener("keydown", handleEscKey);
     },
     setPosition() {
         if (this.dpContainer.style.visibility !== STYLE_VISIBILITY_VISIBLE) {
@@ -400,6 +402,14 @@ function addEventListenerOnBody() {
         }
         jalaliDatepicker.hide();
     });
+}
+
+function handleEscKey(event) {
+    if (event.key === "Escape") {
+        document.removeEventListener("keydown", handleEscKey);
+        jalaliDatepicker.input.blur();
+        jalaliDatepicker.hide();
+    }
 }
 
 window.jalaliDatepicker = {

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ import {
     CONTAINER_ELM_QUERY,
     OVERLAY_ELM_QUERY,
     EVENT_FOCUS_STR,
+    EVENT_KEYDOWN_STR,
     EVENT_CHANGE_INPUT_STR,
     MIN_MAX_TODAY_SETTING,
     MIN_MAX_ATTR_SETTING,
@@ -59,6 +60,7 @@ const jalaliDatepicker = {
     },
     options: defaults,
     input: null,
+    isTransitioning: false,
     get dpContainer() {
         if (!this._dpContainer || !this._dpContainer.isConnected) {
             this._dpContainer = createElement(CONTAINER_ELM_QUERY, this.options.container);
@@ -139,6 +141,7 @@ const jalaliDatepicker = {
         this.input = input;
         this._draw();
         setReadOnly(input, this.options);
+        this.isTransitioning = true;
         this.dpContainer.style.visibility = STYLE_VISIBILITY_VISIBLE;
         this.dpContainer.style.display = STYLE_DISPLAY_BLOCK;
         this.overlayElm.style.display = STYLE_DISPLAY_BLOCK;
@@ -147,17 +150,18 @@ const jalaliDatepicker = {
             this.dpContainer.style.display = STYLE_DISPLAY_BLOCK;
             this.overlayElm.style.display = STYLE_DISPLAY_BLOCK;
             this.isShow=true;
+            this.isTransitioning = false;
         }, 300);
         this.setPosition();
         setScrollOnParent(input);
-        document.addEventListener("keydown", handleEscKey);
+        document.addEventListener(EVENT_KEYDOWN_STR, handleEscKey);
     },
     hide() {
         this.dpContainer.style.visibility = STYLE_VISIBILITY_HIDDEN;
         this.dpContainer.style.display = STYLE_DISPLAY_HIDDEN;
         this.overlayElm.style.display = STYLE_DISPLAY_HIDDEN;
         this.isShow = false;
-        document.removeEventListener("keydown", handleEscKey);
+        document.removeEventListener(EVENT_KEYDOWN_STR, handleEscKey);
     },
     setPosition() {
         if (this.dpContainer.style.visibility !== STYLE_VISIBILITY_VISIBLE) {
@@ -406,9 +410,10 @@ function addEventListenerOnBody() {
 
 function handleEscKey(event) {
     if (event.key === "Escape") {
-        document.removeEventListener("keydown", handleEscKey);
-        jalaliDatepicker.input.blur();
-        jalaliDatepicker.hide();
+        if (!jalaliDatepicker.isTransitioning) {
+            jalaliDatepicker.input?.blur?.();
+            jalaliDatepicker.hide();
+        }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds support for closing the JalaliDatePicker when the **Escape** key is pressed.  
It also removes focus from the input field to allow the datepicker to reopen properly afterward.

---

### Why is this needed?

In Angular applications, pressing the Escape key can typically close modals or dialogs.  
However, when **JalaliDatePicker** was open and Escape was pressed, only the dialog would close —  
while the datepicker remained visible and active. This created a **confusing UX**, where the user  
thought everything was dismissed, but the datepicker was still open and blocked interaction.

---

### Changes made:
- Introduced a `handleEscKey` function to listen for Escape key events
- Registered the keydown listener inside the `show()` method
- On Escape:
  - The input is blurred (`blur()` called)
  - Datepicker is hidden via existing `hide()` method
  - Event listener is removed for cleanup

---